### PR TITLE
feat: Implement Collections Lexicon Definition

### DIFF
--- a/docs/lexicons/collections.md
+++ b/docs/lexicons/collections.md
@@ -1,0 +1,136 @@
+# Collections Lexicon Definition
+
+## Overview
+
+The Collections lexicon (`dev.chrispardy.collections`) defines the schema for recipe collections stored in the user's Personal Data Server (PDS). Collections allow users to organize recipes into custom groups.
+
+## Lexicon Schema
+
+**Namespace:** `dev.chrispardy.collections`  
+**Type:** Record  
+**Location:** `lexicons/dev.chrispardy.collections.json`
+
+## Record Schema
+
+### Required Fields
+
+- **name** (string, required)
+  - The name of the collection
+  - Must be a non-empty string
+  - Maximum length: 100 characters
+  - Example: `"My Favorite Recipes"`
+
+- **recipeUris** (array of strings, required)
+  - Array of recipe record URIs (ATProto URIs)
+  - Each URI must be a valid ATProto URI pointing to a recipe record
+  - Format: `at://did:plc:.../dev.chrispardy.recipes/rkey`
+  - Maximum items: 1000
+  - Can be empty array
+  - Example: `["at://did:plc:abc123/dev.chrispardy.recipes/recipe-1"]`
+
+- **createdAt** (string, required)
+  - ISO 8601 timestamp indicating when the collection was created
+  - Format: ISO 8601 datetime (e.g., `"2024-01-01T00:00:00.000Z"`)
+  - Example: `"2024-01-01T12:30:45.123Z"`
+
+- **updatedAt** (string, required)
+  - ISO 8601 timestamp indicating when the collection was last updated
+  - Format: ISO 8601 datetime (e.g., `"2024-01-01T00:00:00.000Z"`)
+  - Must be equal to or after `createdAt`
+  - Example: `"2024-01-02T15:45:30.456Z"`
+
+### Optional Fields
+
+- **description** (string, optional)
+  - Optional description of the collection
+  - Provides additional context about the collection's purpose or contents
+  - Maximum length: 500 characters
+  - Example: `"A collection of my favorite dessert recipes"`
+
+## Validation Rules
+
+1. **Name Validation**
+   - Must be present and non-empty (after trimming whitespace)
+   - Must be a string
+   - Maximum 100 characters
+
+2. **Description Validation**
+   - If provided, must be a string
+   - Maximum 500 characters
+   - Can be an empty string
+
+3. **Recipe URIs Validation**
+   - Must be an array
+   - Maximum 1000 items
+   - Each item must be a valid ATProto URI
+   - URI format: `at://did:plc:.../collection/rkey`
+
+4. **Timestamp Validation**
+   - Both `createdAt` and `updatedAt` must be valid ISO 8601 datetime strings
+   - `updatedAt` must be equal to or after `createdAt`
+
+## TypeScript Types
+
+The TypeScript types are defined in `src/types/collection.ts`:
+
+```typescript
+export interface Collection {
+  name: string
+  description?: string
+  recipeUris: string[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CollectionRecord extends Collection {
+  $type: 'dev.chrispardy.collections'
+}
+```
+
+## Validation Functions
+
+Validation utilities are available in `src/utils/collectionValidation.ts`:
+
+- `validateCollection(collection: Collection): void` - Validates a Collection object
+- `validateCollectionRecord(record: CollectionRecord): void` - Validates a CollectionRecord
+- `createValidCollection(data): Collection` - Creates a valid Collection with current timestamps
+
+## Example Record
+
+```json
+{
+  "$type": "dev.chrispardy.collections",
+  "name": "Dessert Recipes",
+  "description": "A collection of my favorite dessert recipes",
+  "recipeUris": [
+    "at://did:plc:abc123/dev.chrispardy.recipes/chocolate-cake",
+    "at://did:plc:abc123/dev.chrispardy.recipes/vanilla-ice-cream"
+  ],
+  "createdAt": "2024-01-01T00:00:00.000Z",
+  "updatedAt": "2024-01-15T12:30:45.123Z"
+}
+```
+
+## Default Collection
+
+The application automatically creates a default collection named "my-saved recipes" when a user saves their first recipe. This collection serves as the default location for saved recipes.
+
+## Use Cases
+
+1. **Organizing Recipes**: Users can create custom collections to organize recipes by category (e.g., "Desserts", "Main Courses", "Vegetarian")
+2. **Recipe Sharing**: Collections can contain both owned recipes (editable) and forked recipes (read-only references)
+3. **Recipe Discovery**: Collections help users discover and group related recipes
+
+## Technical Notes
+
+- Collections are stored in the user's PDS, not just in IndexedDB
+- Collections contain references to recipe URIs, not full recipe data
+- A recipe can belong to multiple collections
+- Collections are public (accessible via URL) like recipes
+- The lexicon follows ATProto lexicon version 1 format
+
+## Related Documentation
+
+- [PRD.md](../../PRD.md) - Product Requirements Document
+- [Collection Types](../../src/types/collection.ts) - TypeScript type definitions
+- [Collection Validation](../../src/utils/collectionValidation.ts) - Validation utilities

--- a/lexicons/dev.chrispardy.collections.json
+++ b/lexicons/dev.chrispardy.collections.json
@@ -1,0 +1,45 @@
+{
+  "lexicon": 1,
+  "id": "dev.chrispardy.collections",
+  "description": "Lexicon definition for recipe collections stored in PDS. Collections allow users to organize recipes into custom groups.",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A collection record that groups recipe URIs together. Collections are stored in the user's PDS and can contain references to both owned and forked recipes.",
+      "record": {
+        "type": "object",
+        "required": ["name", "recipeUris", "createdAt", "updatedAt"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the collection. Must be a non-empty string.",
+            "maxLength": 100
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional description of the collection. Provides additional context about the collection's purpose or contents.",
+            "maxLength": 500
+          },
+          "recipeUris": {
+            "type": "array",
+            "description": "Array of recipe record URIs (ATProto URIs) that belong to this collection. URIs must be valid ATProto URIs pointing to recipe records.",
+            "items": {
+              "type": "string"
+            },
+            "maxLength": 1000
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO 8601 timestamp indicating when the collection was created.",
+            "format": "datetime"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "ISO 8601 timestamp indicating when the collection was last updated.",
+            "format": "datetime"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/types/collection.ts
+++ b/src/types/collection.ts
@@ -1,19 +1,41 @@
 /**
  * TypeScript types for Collections
  * Based on ATProto custom lexicon: dev.chrispardy.collections
+ * 
+ * Lexicon definition: lexicons/dev.chrispardy.collections.json
+ * 
+ * Collections allow users to organize recipes into custom groups.
+ * Collections are stored in the user's PDS and can contain references
+ * to both owned and forked recipes.
  */
 
+/**
+ * Collection interface matching the ATProto lexicon schema
+ * 
+ * @property name - The name of the collection (required, max 100 characters)
+ * @property description - Optional description of the collection (max 500 characters)
+ * @property recipeUris - Array of recipe record URIs (ATProto URIs, max 1000 items)
+ * @property createdAt - ISO 8601 timestamp indicating when the collection was created
+ * @property updatedAt - ISO 8601 timestamp indicating when the collection was last updated
+ */
 export interface Collection {
+  /** Collection name (required, non-empty, max 100 characters) */
   name: string
+  /** Optional description (max 500 characters) */
   description?: string
-  recipeUris: string[] // Array of recipe record URIs
-  createdAt: string // ISO timestamp
-  updatedAt: string // ISO timestamp
+  /** Array of recipe record URIs (ATProto URIs, max 1000 items) */
+  recipeUris: string[]
+  /** ISO 8601 timestamp indicating when the collection was created */
+  createdAt: string
+  /** ISO 8601 timestamp indicating when the collection was last updated */
+  updatedAt: string
 }
 
 /**
  * ATProto record representation of a Collection
+ * Includes the $type field required for ATProto records
  */
 export interface CollectionRecord extends Collection {
+  /** ATProto record type identifier */
   $type: 'dev.chrispardy.collections'
 }

--- a/src/utils/collectionValidation.test.ts
+++ b/src/utils/collectionValidation.test.ts
@@ -195,6 +195,15 @@ describe('collectionValidation', () => {
         expect(() => validateCollection(collection)).toThrow('must be a valid ATProto URI')
       })
 
+      it('should throw if recipeUris contains URIs without did: prefix', () => {
+        const collection: Collection = {
+          ...validCollection,
+          recipeUris: ['at://not-a-did/collection/rkey'],
+        }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow('must be a valid ATProto URI')
+      })
+
       it('should accept valid ATProto URIs', () => {
         const collection: Collection = {
           ...validCollection,
@@ -235,11 +244,20 @@ describe('collectionValidation', () => {
         expect(() => validateCollection(collection)).toThrow('createdAt must be a valid ISO 8601')
       })
 
-      it('should accept valid ISO datetime strings', () => {
+      it('should accept valid ISO datetime strings with milliseconds', () => {
         const collection: Collection = {
           ...validCollection,
           createdAt: '2024-01-01T12:30:45.123Z',
           updatedAt: '2024-01-01T12:30:45.123Z', // Must be >= createdAt
+        }
+        expect(() => validateCollection(collection)).not.toThrow()
+      })
+
+      it('should accept valid ISO datetime strings without milliseconds', () => {
+        const collection: Collection = {
+          ...validCollection,
+          createdAt: '2024-01-01T12:30:45Z',
+          updatedAt: '2024-01-01T12:30:45Z', // Must be >= createdAt
         }
         expect(() => validateCollection(collection)).not.toThrow()
       })
@@ -299,6 +317,15 @@ describe('collectionValidation', () => {
           ...validCollection,
           createdAt: '2024-01-01T00:00:00.000Z',
           updatedAt: '2024-01-02T00:00:00.000Z',
+        }
+        expect(() => validateCollection(collection)).not.toThrow()
+      })
+
+      it('should accept ISO datetime strings without milliseconds for updatedAt', () => {
+        const collection: Collection = {
+          ...validCollection,
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-02T00:00:00Z',
         }
         expect(() => validateCollection(collection)).not.toThrow()
       })

--- a/src/utils/collectionValidation.test.ts
+++ b/src/utils/collectionValidation.test.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateCollection,
+  validateCollectionRecord,
+  createValidCollection,
+  CollectionValidationError,
+} from './collectionValidation'
+import type { Collection, CollectionRecord } from '../types/collection'
+
+describe('collectionValidation', () => {
+  const validCollection: Collection = {
+    name: 'My Recipes',
+    description: 'A collection of my favorite recipes',
+    recipeUris: [
+      'at://did:plc:123/dev.chrispardy.recipes/1',
+      'at://did:plc:123/dev.chrispardy.recipes/2',
+    ],
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+  }
+
+  describe('validateCollection', () => {
+    it('should validate a valid collection', () => {
+      expect(() => validateCollection(validCollection)).not.toThrow()
+    })
+
+    it('should validate a collection without description', () => {
+      const collection: Collection = {
+        ...validCollection,
+        description: undefined,
+      }
+      expect(() => validateCollection(collection)).not.toThrow()
+    })
+
+    it('should validate a collection with empty recipeUris array', () => {
+      const collection: Collection = {
+        ...validCollection,
+        recipeUris: [],
+      }
+      expect(() => validateCollection(collection)).not.toThrow()
+    })
+
+    describe('name validation', () => {
+      it('should throw if name is missing', () => {
+        const collection = { ...validCollection, name: undefined as unknown as string }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow('name is required')
+      })
+
+      it('should throw if name is not a string', () => {
+        const collection = { ...validCollection, name: 123 as unknown as string }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow('name')
+      })
+
+      it('should throw if name is empty', () => {
+        const collection: Collection = {
+          ...validCollection,
+          name: '',
+        }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow('name cannot be empty')
+      })
+
+      it('should throw if name is only whitespace', () => {
+        const collection: Collection = {
+          ...validCollection,
+          name: '   ',
+        }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow('name cannot be empty')
+      })
+
+      it('should throw if name exceeds 100 characters', () => {
+        const collection: Collection = {
+          ...validCollection,
+          name: 'a'.repeat(101),
+        }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow('name must be 100 characters or less')
+      })
+
+      it('should accept name with exactly 100 characters', () => {
+        const collection: Collection = {
+          ...validCollection,
+          name: 'a'.repeat(100),
+        }
+        expect(() => validateCollection(collection)).not.toThrow()
+      })
+    })
+
+    describe('description validation', () => {
+      it('should accept undefined description', () => {
+        const collection: Collection = {
+          ...validCollection,
+          description: undefined,
+        }
+        expect(() => validateCollection(collection)).not.toThrow()
+      })
+
+      it('should throw if description is not a string', () => {
+        const collection = {
+          ...validCollection,
+          description: 123 as unknown as string,
+        }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow('description')
+      })
+
+      it('should throw if description exceeds 500 characters', () => {
+        const collection: Collection = {
+          ...validCollection,
+          description: 'a'.repeat(501),
+        }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow(
+          'description must be 500 characters or less',
+        )
+      })
+
+      it('should accept description with exactly 500 characters', () => {
+        const collection: Collection = {
+          ...validCollection,
+          description: 'a'.repeat(500),
+        }
+        expect(() => validateCollection(collection)).not.toThrow()
+      })
+
+      it('should accept empty description string', () => {
+        const collection: Collection = {
+          ...validCollection,
+          description: '',
+        }
+        expect(() => validateCollection(collection)).not.toThrow()
+      })
+    })
+
+    describe('recipeUris validation', () => {
+      it('should throw if recipeUris is missing', () => {
+        const collection = {
+          ...validCollection,
+          recipeUris: undefined as unknown as string[],
+        }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow('recipeUris must be an array')
+      })
+
+      it('should throw if recipeUris is not an array', () => {
+        const collection = {
+          ...validCollection,
+          recipeUris: 'not an array' as unknown as string[],
+        }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow('recipeUris must be an array')
+      })
+
+      it('should throw if recipeUris exceeds 1000 items', () => {
+        const collection: Collection = {
+          ...validCollection,
+          recipeUris: Array.from({ length: 1001 }, (_, i) =>
+            `at://did:plc:123/dev.chrispardy.recipes/${i}`,
+          ),
+        }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow(
+          'recipeUris array cannot contain more than 1000 items',
+        )
+      })
+
+      it('should accept recipeUris with exactly 1000 items', () => {
+        const collection: Collection = {
+          ...validCollection,
+          recipeUris: Array.from({ length: 1000 }, (_, i) =>
+            `at://did:plc:123/dev.chrispardy.recipes/${i}`,
+          ),
+        }
+        expect(() => validateCollection(collection)).not.toThrow()
+      })
+
+      it('should throw if recipeUris contains non-string items', () => {
+        const collection = {
+          ...validCollection,
+          recipeUris: ['at://did:plc:123/dev.chrispardy.recipes/1', 123] as unknown as string[],
+        }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow('recipeUris[1] must be a string')
+      })
+
+      it('should throw if recipeUris contains invalid ATProto URIs', () => {
+        const collection: Collection = {
+          ...validCollection,
+          recipeUris: ['invalid-uri', 'also-invalid'],
+        }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow('must be a valid ATProto URI')
+      })
+
+      it('should accept valid ATProto URIs', () => {
+        const collection: Collection = {
+          ...validCollection,
+          recipeUris: [
+            'at://did:plc:abc123/dev.chrispardy.recipes/recipe-1',
+            'at://did:plc:xyz789/com.example.recipes/recipe-2',
+          ],
+        }
+        expect(() => validateCollection(collection)).not.toThrow()
+      })
+    })
+
+    describe('createdAt validation', () => {
+      it('should throw if createdAt is missing', () => {
+        const collection = {
+          ...validCollection,
+          createdAt: undefined as unknown as string,
+        }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow('createdAt is required')
+      })
+
+      it('should throw if createdAt is not a string', () => {
+        const collection = {
+          ...validCollection,
+          createdAt: 123 as unknown as string,
+        }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow('createdAt')
+      })
+
+      it('should throw if createdAt is not a valid ISO datetime', () => {
+        const collection: Collection = {
+          ...validCollection,
+          createdAt: 'not-a-date',
+        }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow('createdAt must be a valid ISO 8601')
+      })
+
+      it('should accept valid ISO datetime strings', () => {
+        const collection: Collection = {
+          ...validCollection,
+          createdAt: '2024-01-01T12:30:45.123Z',
+          updatedAt: '2024-01-01T12:30:45.123Z', // Must be >= createdAt
+        }
+        expect(() => validateCollection(collection)).not.toThrow()
+      })
+    })
+
+    describe('updatedAt validation', () => {
+      it('should throw if updatedAt is missing', () => {
+        const collection = {
+          ...validCollection,
+          updatedAt: undefined as unknown as string,
+        }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow('updatedAt is required')
+      })
+
+      it('should throw if updatedAt is not a string', () => {
+        const collection = {
+          ...validCollection,
+          updatedAt: 123 as unknown as string,
+        }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow('updatedAt')
+      })
+
+      it('should throw if updatedAt is not a valid ISO datetime', () => {
+        const collection: Collection = {
+          ...validCollection,
+          updatedAt: 'not-a-date',
+        }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow('updatedAt must be a valid ISO 8601')
+      })
+
+      it('should throw if updatedAt is before createdAt', () => {
+        const collection: Collection = {
+          ...validCollection,
+          createdAt: '2024-01-02T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+        }
+        expect(() => validateCollection(collection)).toThrow(CollectionValidationError)
+        expect(() => validateCollection(collection)).toThrow(
+          'updatedAt cannot be before createdAt',
+        )
+      })
+
+      it('should accept updatedAt equal to createdAt', () => {
+        const collection: Collection = {
+          ...validCollection,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+        }
+        expect(() => validateCollection(collection)).not.toThrow()
+      })
+
+      it('should accept updatedAt after createdAt', () => {
+        const collection: Collection = {
+          ...validCollection,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-02T00:00:00.000Z',
+        }
+        expect(() => validateCollection(collection)).not.toThrow()
+      })
+    })
+  })
+
+  describe('validateCollectionRecord', () => {
+    it('should validate a valid collection record', () => {
+      const record: CollectionRecord = {
+        $type: 'dev.chrispardy.collections',
+        ...validCollection,
+      }
+      expect(() => validateCollectionRecord(record)).not.toThrow()
+    })
+
+    it('should throw if $type is incorrect', () => {
+      const record = {
+        $type: 'dev.chrispardy.recipes',
+        ...validCollection,
+      } as CollectionRecord
+
+      expect(() => validateCollectionRecord(record)).toThrow(CollectionValidationError)
+      expect(() => validateCollectionRecord(record)).toThrow('Invalid $type')
+    })
+
+    it('should validate all collection fields in addition to $type', () => {
+      const record = {
+        $type: 'dev.chrispardy.collections',
+        ...validCollection,
+        name: '', // Invalid name
+      } as CollectionRecord
+
+      expect(() => validateCollectionRecord(record)).toThrow(CollectionValidationError)
+      expect(() => validateCollectionRecord(record)).toThrow('name cannot be empty')
+    })
+  })
+
+  describe('createValidCollection', () => {
+    it('should create a valid collection with current timestamps', () => {
+      const before = new Date()
+      const collection = createValidCollection({
+        name: 'Test Collection',
+        recipeUris: ['at://did:plc:123/dev.chrispardy.recipes/1'],
+      })
+      const after = new Date()
+
+      expect(collection.name).toBe('Test Collection')
+      expect(collection.recipeUris).toHaveLength(1)
+      expect(collection.createdAt).toBeDefined()
+      expect(collection.updatedAt).toBeDefined()
+
+      const createdAt = new Date(collection.createdAt)
+      const updatedAt = new Date(collection.updatedAt)
+
+      expect(createdAt.getTime()).toBeGreaterThanOrEqual(before.getTime())
+      expect(createdAt.getTime()).toBeLessThanOrEqual(after.getTime())
+      expect(updatedAt.getTime()).toBeGreaterThanOrEqual(before.getTime())
+      expect(updatedAt.getTime()).toBeLessThanOrEqual(after.getTime())
+      expect(createdAt.getTime()).toBe(updatedAt.getTime())
+    })
+
+    it('should use empty array for recipeUris if not provided', () => {
+      const collection = createValidCollection({
+        name: 'Test Collection',
+      })
+
+      expect(collection.recipeUris).toEqual([])
+    })
+
+    it('should include description if provided', () => {
+      const collection = createValidCollection({
+        name: 'Test Collection',
+        description: 'Test description',
+        recipeUris: [],
+      })
+
+      expect(collection.description).toBe('Test description')
+    })
+
+    it('should throw if provided data is invalid', () => {
+      expect(() =>
+        createValidCollection({
+          name: '', // Invalid: empty name
+          recipeUris: [],
+        }),
+      ).toThrow(CollectionValidationError)
+    })
+
+    it('should create a collection that passes validation', () => {
+      const collection = createValidCollection({
+        name: 'Test Collection',
+        description: 'Test',
+        recipeUris: ['at://did:plc:123/dev.chrispardy.recipes/1'],
+      })
+
+      expect(() => validateCollection(collection)).not.toThrow()
+    })
+  })
+})

--- a/src/utils/collectionValidation.ts
+++ b/src/utils/collectionValidation.ts
@@ -17,18 +17,33 @@ export class CollectionValidationError extends Error {
 
 /**
  * Validates that a string is a valid ATProto URI
- * Basic validation - checks for at:// prefix and basic structure
+ * Validates that the URI has the correct structure and that the first segment is a DID
+ * @internal - Internal utility function, not exported
  */
 function isValidAtProtoUri(uri: string): boolean {
-  return /^at:\/\/[^/]+\/[^/]+\/[^/]+$/.test(uri)
+  if (!uri.startsWith('at://')) {
+    return false
+  }
+  const uriParts = uri.replace('at://', '').split('/')
+  if (uriParts.length < 3) {
+    return false
+  }
+  // Validate that the first part is a DID
+  return uriParts[0].startsWith('did:')
 }
 
 /**
  * Validates that a string is a valid ISO 8601 datetime
+ * Accepts ISO strings with or without milliseconds
+ * @internal - Internal utility function, not exported
  */
 function isValidIsoDateTime(dateString: string): boolean {
   const date = new Date(dateString)
-  return !isNaN(date.getTime()) && dateString === date.toISOString()
+  if (isNaN(date.getTime())) {
+    return false
+  }
+  // Check if it's a valid ISO 8601 format (more flexible - accepts with or without milliseconds)
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/.test(dateString)
 }
 
 /**

--- a/src/utils/collectionValidation.ts
+++ b/src/utils/collectionValidation.ts
@@ -1,0 +1,198 @@
+/**
+ * Validation utilities for Collection records
+ * Validates collections against the ATProto lexicon schema: dev.chrispardy.collections
+ */
+
+import type { Collection, CollectionRecord } from '../types/collection'
+
+/**
+ * Validation error for collection records
+ */
+export class CollectionValidationError extends Error {
+  constructor(message: string, public field?: string) {
+    super(message)
+    this.name = 'CollectionValidationError'
+  }
+}
+
+/**
+ * Validates that a string is a valid ATProto URI
+ * Basic validation - checks for at:// prefix and basic structure
+ */
+function isValidAtProtoUri(uri: string): boolean {
+  return /^at:\/\/[^/]+\/[^/]+\/[^/]+$/.test(uri)
+}
+
+/**
+ * Validates that a string is a valid ISO 8601 datetime
+ */
+function isValidIsoDateTime(dateString: string): boolean {
+  const date = new Date(dateString)
+  return !isNaN(date.getTime()) && dateString === date.toISOString()
+}
+
+/**
+ * Validates a Collection record against the lexicon schema
+ * @param collection - The collection to validate
+ * @throws CollectionValidationError if validation fails
+ */
+export function validateCollection(collection: Collection): void {
+  // Validate name (required, non-empty, max 100 characters)
+  if (collection.name === undefined || collection.name === null) {
+    throw new CollectionValidationError(
+      'Collection name is required and must be a string',
+      'name',
+    )
+  }
+
+  if (typeof collection.name !== 'string') {
+    throw new CollectionValidationError(
+      'Collection name is required and must be a string',
+      'name',
+    )
+  }
+
+  if (collection.name.trim().length === 0) {
+    throw new CollectionValidationError(
+      'Collection name cannot be empty',
+      'name',
+    )
+  }
+
+  if (collection.name.length > 100) {
+    throw new CollectionValidationError(
+      'Collection name must be 100 characters or less',
+      'name',
+    )
+  }
+
+  // Validate description (optional, max 500 characters if provided)
+  if (collection.description !== undefined) {
+    if (typeof collection.description !== 'string') {
+      throw new CollectionValidationError(
+        'Collection description must be a string',
+        'description',
+      )
+    }
+
+    if (collection.description.length > 500) {
+      throw new CollectionValidationError(
+        'Collection description must be 500 characters or less',
+        'description',
+      )
+    }
+  }
+
+  // Validate recipeUris (required, array, max 1000 items)
+  if (!Array.isArray(collection.recipeUris)) {
+    throw new CollectionValidationError(
+      'recipeUris must be an array',
+      'recipeUris',
+    )
+  }
+
+  if (collection.recipeUris.length > 1000) {
+    throw new CollectionValidationError(
+      'recipeUris array cannot contain more than 1000 items',
+      'recipeUris',
+    )
+  }
+
+  // Validate each URI in recipeUris
+  for (let i = 0; i < collection.recipeUris.length; i++) {
+    const uri = collection.recipeUris[i]
+    if (typeof uri !== 'string') {
+      throw new CollectionValidationError(
+        `recipeUris[${i}] must be a string`,
+        'recipeUris',
+      )
+    }
+
+    if (!isValidAtProtoUri(uri)) {
+      throw new CollectionValidationError(
+        `recipeUris[${i}] must be a valid ATProto URI (format: at://did:plc:.../collection/rkey)`,
+        'recipeUris',
+      )
+    }
+  }
+
+  // Validate createdAt (required, ISO 8601 datetime)
+  if (!collection.createdAt || typeof collection.createdAt !== 'string') {
+    throw new CollectionValidationError(
+      'createdAt is required and must be a string',
+      'createdAt',
+    )
+  }
+
+  if (!isValidIsoDateTime(collection.createdAt)) {
+    throw new CollectionValidationError(
+      'createdAt must be a valid ISO 8601 datetime string',
+      'createdAt',
+    )
+  }
+
+  // Validate updatedAt (required, ISO 8601 datetime)
+  if (!collection.updatedAt || typeof collection.updatedAt !== 'string') {
+    throw new CollectionValidationError(
+      'updatedAt is required and must be a string',
+      'updatedAt',
+    )
+  }
+
+  if (!isValidIsoDateTime(collection.updatedAt)) {
+    throw new CollectionValidationError(
+      'updatedAt must be a valid ISO 8601 datetime string',
+      'updatedAt',
+    )
+  }
+
+  // Validate that updatedAt is not before createdAt
+  const createdAt = new Date(collection.createdAt)
+  const updatedAt = new Date(collection.updatedAt)
+
+  if (updatedAt < createdAt) {
+    throw new CollectionValidationError(
+      'updatedAt cannot be before createdAt',
+      'updatedAt',
+    )
+  }
+}
+
+/**
+ * Validates a CollectionRecord (includes $type field)
+ * @param record - The collection record to validate
+ * @throws CollectionValidationError if validation fails
+ */
+export function validateCollectionRecord(record: CollectionRecord): void {
+  // Validate $type field
+  if (record.$type !== 'dev.chrispardy.collections') {
+    throw new CollectionValidationError(
+      `Invalid $type: expected 'dev.chrispardy.collections', got '${record.$type}'`,
+      '$type',
+    )
+  }
+
+  // Validate the collection data
+  validateCollection(record)
+}
+
+/**
+ * Creates a valid Collection with default timestamps
+ * @param data - Collection data (without timestamps)
+ * @returns A valid Collection with createdAt and updatedAt set to current time
+ */
+export function createValidCollection(
+  data: Omit<Collection, 'createdAt' | 'updatedAt'>,
+): Collection {
+  const now = new Date().toISOString()
+
+  const collection: Collection = {
+    ...data,
+    recipeUris: data.recipeUris || [],
+    createdAt: now,
+    updatedAt: now,
+  }
+
+  validateCollection(collection)
+  return collection
+}


### PR DESCRIPTION
This PR implements the Collections lexicon definition for ATProto as specified in issue #20.

## Changes

- ✅ Created ATProto lexicon JSON schema file ()
- ✅ Updated TypeScript types with JSDoc comments referencing the lexicon
- ✅ Added comprehensive validation functions ()
- ✅ Created comprehensive unit tests (39 tests, all passing)
- ✅ Added lexicon documentation ()

## Lexicon Schema

The lexicon defines collections with:
- **name**: required, max 100 characters
- **description**: optional, max 500 characters  
- **recipeUris**: required array of ATProto URIs, max 1000 items
- **createdAt/updatedAt**: required ISO 8601 timestamps

## Validation

The validation functions check:
- Field types and presence
- Length constraints (name, description, recipeUris array)
- ATProto URI format validation
- ISO datetime format validation
- Timestamp ordering (updatedAt >= createdAt)

## Testing

All tests pass:
- 39 validation tests covering all edge cases
- Existing collection type tests still pass
- No breaking changes to existing code

Closes #20